### PR TITLE
automatically detect arch phys cars for install_arch_cars script + better AC path detection

### DIFF
--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -116,121 +116,60 @@ function Install-Car {
     }
 }
 
-$arch_car = 'arch_mazda_miata_na8c_1994'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_Miata_NA*"
-$kunos_car = 'ks_mazda_miata'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
+# get all folders inside "$script:girellu\Releases\Mods\Arch Cars Public\"
+$dirs = Get-ChildItem -Path "$script:girellu\Releases\Mods\Arch Cars Public\"
 
-$arch_car = 'arch_mazda_miata_na8c_1994_s1'
-$kunos_car = 'ks_mazda_miata'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_mazda_miata_nd1_2016'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_Miata_ND*"
-$kunos_car = 'ks_mazda_mx5_nd'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_mazda_miata_nd1_2016_s1'
-$kunos_car = 'ks_mazda_mx5_nd'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_mazda_fd3s_2002_spiritr'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_RX7_FD3S*"
-$kunos_car = 'ks_mazda_rx7_spirit_r'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_mazda_fd3s_1999_drift'
-$kunos_car = 'ks_mazda_rx7_tuned'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'm7_nissan_r34_gtr_1999_vspec'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_R34 GT-R_V-spec*"
-$kunos_car = 'ks_nissan_skyline_r34'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_ae86_sprinter_trueno_gtapex_1983'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_AE86_Trueno*"
-$kunos_car = 'ks_toyota_ae86'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_ae86_sprinter_trueno_gtv_1983'
-$kunos_car = 'ks_toyota_ae86'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_ae86_sprinter_trueno_1983_s1'
-$kunos_car = 'ks_toyota_ae86'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_ae86_sprinter_trueno_1983_s2'
-$kunos_car = 'ks_toyota_ae86_tuned'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_ae86_sprinter_trueno_1983_drift'
-$kunos_car = 'ks_toyota_ae86_drift'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_gt86_2015_gt'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_GT86*"
-$kunos_car = 'ks_toyota_gt86'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_supra_a80_1997_rz'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_Supra_JZA80*"
-$kunos_car = 'ks_toyota_supra_mkiv'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_toyota_supra_a80_1997_drift'
-$kunos_car = 'ks_toyota_supra_mkiv_drift'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_bmw_m3_e30_1992_dtm'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_M3_E30_DTM_*"
-$kunos_car = 'bmw_m3_e30_dtm'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_bmw_m3_e30_1986'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_M3_E30*"
-$kunos_car = 'bmw_m3_e30'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_bmw_m3_e30_1986_drift'
-$kunos_car = 'bmw_m3_e30_drift'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_bmw_m3_e30_evo3_1990'
-$kunos_car = 'bmw_m3_e30'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_mercedes_190e_evoii_1992_dtm'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_190E_DTM*"
-$kunos_car = 'ks_mercedes_190_evo2'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_porsche_911_rsr_1974_grp4'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_911_RSR_*"
-$kunos_car = 'ks_porsche_911_carrera_rsr'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_ruf_ctr_1987'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_CTR1_*"
-$kunos_car = 'ruf_yellowbird'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
-
-$arch_car = 'arch_lotus_elise_sc_tp_2008'
-$arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_Elise*"
-$kunos_car = 'lotus_elise_sc'
-Install-Car $arch_folder $arch_car $kunos_car $ac_root
+foreach ($dir in $dirs) {
+    if (Test-Path -Path "$dir\content\cars\") {
 
 
-$path = -join($ac_root, "\content\cars\", "ks_porsche_935_78_moby_dick");
-if (Test-Path -Path $path) {
-    $arch_car = 'arch_porsche_935_78_1978_grp5'
-    $arch_folder = "$script:girellu\Releases\Mods\Arch Cars Public\Modified_physics_for_935_78*"
-    $kunos_car = 'ks_porsche_935_78_moby_dick'
-    Install-Car $arch_folder $arch_car $kunos_car $ac_root
-} else {
-    Write-Host 'Did not find moby dick, skipping install.'
-    Exit
+        $arch_cars = $()
+
+        # get all folders inside "$dir\content\cars\" and add them to $arch_cars array
+        $arch_cars = Get-ChildItem -Path "$dir\content\cars\"
+
+
+        $arch_cars = $arch_cars | Select-Object -Unique
+
+    
+
+        foreach ($arch_car in $arch_cars) {
+            if ($arch_car -match "_") {
+                if ($arch_car -inotmatch " ") {
+                    $kunos_car = ""
+
+                    $ext_config = Get-Content -Path "$dir\content\cars\$arch_car\extension\ext_config.ini"
+
+                    $ext_config | Where-Object { $_ -match "cars/kunos/" } | Select-String -Pattern "cars/kunos/(.*).ini" | ForEach-Object { $kunos_car = @($_.Matches.Value) }
+
+                    # strip .ini and "cars/kunos/" from $kunos_car
+                    $kunos_car = $kunos_car.Replace(".ini", "").Replace("cars/kunos/", "")
+
+                    if ($kunos_car -eq "") {
+                        # read "!README AND INSTRUCTIONS.txt" in $dir
+                        $readme = Get-Content -Path "$dir\!README AND INSTRUCTIONS.txt"
+
+                        # find line with "copy from folder" inside $readme and strip it
+                        $readme | Where-Object { $_ -match "copy from folder" } | Select-String -Pattern "copy from folder(.*)" | ForEach-Object { $kunos_car = @($_.Matches.Value).Replace("copy from folder ", "") }
+
+                        Write-Host "alternative check $kunos_car succesful" -ForegroundColor Green
+                    }
+
+                    if ($kunos_car -eq "") {
+                        Write-Host "Could not find kunos car for $arch_car" -ForegroundColor Red
+                    } else {
+                        $path = -join($ac_root, "\content\cars\", $kunos_car);
+
+                        if (Test-Path -Path $path) {
+                            Install-Car $dir $arch_car $kunos_car $ac_root
+                        } else {
+                            Write-Host "Could not find $kunos_car, you may be missing DLC, this car will be skipped." -BackgroundColor Red
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 Write-Host 'Success!'

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -131,12 +131,25 @@ foreach ($dir in $dirs) {
                 if ($arch_car -inotmatch " ") {
                     $kunos_car = ""
 
-                    $ext_config = Get-Content -Path "$dir\content\cars\$arch_car\extension\ext_config.ini"
-                    $ext_config | Where-Object { $_ -match "cars/kunos/" } | Select-String -Pattern "cars/kunos/(.*).ini" | ForEach-Object { $kunos_car = @($_.Matches.Value) }
+
+                    $donor_cars = Get-Content -Path "$script:girellu\Releases\Mods\Arch Cars Public\donor_cars.txt"
+                    foreach ($donor_car in $donor_cars) {
+                        # seperate $donor_car by comma into array
+                        $donor_car = $donor_car -split ","
+                        # if $arch_car matches first entry, set $kunos_car to second entry
+                        if ($arch_car -match $donor_car[0]) {
+                            $kunos_car = $donor_car[1]
+                        }
+                    }
                     
-                    # strip .ini and "cars/kunos/" from $kunos_car
-                    $kunos_car = $kunos_car.Replace(".ini", "").Replace("cars/kunos/", "")
-                    if ($kunos_car -eq "") {
+                    if ($kunos_car -eq "") { # this should only get triggered if new cars werent added to donor_cars.txt
+                        $ext_config = Get-Content -Path "$dir\content\cars\$arch_car\extension\ext_config.ini"
+                        $ext_config | Where-Object { $_ -match "cars/kunos/" } | Select-String -Pattern "cars/kunos/(.*).ini" | ForEach-Object { $kunos_car = @($_.Matches.Value) }
+                        
+                        # strip .ini and "cars/kunos/" from $kunos_car
+                        $kunos_car = $kunos_car.Replace(".ini", "").Replace("cars/kunos/", "")
+                    }
+                    if ($kunos_car -eq "") { # ideally, this should never get triggered, because it's horrible code that will likely fail
                         # read "!README AND INSTRUCTIONS.txt" in $dir
                         $readme = Get-Content -Path "$dir\!README AND INSTRUCTIONS.txt"
                         $kunos_candidates = $()

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -133,14 +133,18 @@ foreach ($dir in $dirs) {
                     $kunos_car = ""
 
 
-                    $donor_cars = Get-Content -Path "$script:girellu\Releases\Mods\Arch Cars Public\donor_cars.txt"
-                    foreach ($donor_car in $donor_cars) {
-                        # seperate $donor_car by comma into array
-                        $donor_car = $donor_car -split ","
-                        # if $arch_car matches first entry, set $kunos_car to second entry
-                        if ($arch_car -match $donor_car[0]) {
-                            $kunos_car = $donor_car[1]
+                    if (Test-Path -Path "$script:girellu\Releases\Mods\Arch Cars Public\donor_cars.txt" -PathType Leaf) {
+                        $donor_cars = Get-Content -Path "$script:girellu\Releases\Mods\Arch Cars Public\donor_cars.txt"
+                        foreach ($donor_car in $donor_cars) {
+                            # seperate $donor_car by comma into array
+                            $donor_car = $donor_car -split ","
+                            # if $arch_car matches first entry, set $kunos_car to second entry
+                            if ($arch_car -match $donor_car[0]) {
+                                $kunos_car = $donor_car[1]
+                            }
                         }
+                    } else {
+                        Write-Host "ERROR: Could not find donor_cars.txt, using fallback method" -ForegroundColor Red
                     }
                     
                     if ($kunos_car -eq "") { # this should only get triggered if new cars werent added to donor_cars.txt

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -139,8 +139,20 @@ foreach ($dir in $dirs) {
                     if ($kunos_car -eq "") {
                         # read "!README AND INSTRUCTIONS.txt" in $dir
                         $readme = Get-Content -Path "$dir\!README AND INSTRUCTIONS.txt"
-                        # find line with "copy from folder" inside $readme and strip it
-                        $readme | Where-Object { $_ -match "copy from folder" } | Select-String -Pattern "copy from folder(.*)" | ForEach-Object { $kunos_car = @($_.Matches.Value).Replace("copy from folder ", "") }
+                        $kunos_candidates = $()
+                        # find every occurance of line with "copy from folder" or "Repeat process from folder" inside $readme and insert them into kunos_candidates array
+                        $kunos_candidates = $readme | Where-Object {  $_ -match "copy from folder" -or $_ -match "Repeat process from folder" } 
+
+                        foreach ($car in $kunos_candidates) {
+                            # strip "copy from folder " from $car
+                            $car = $car.Replace("copy from folder ", "").Replace('"', '').Replace('Repeat process from folder ', '').Replace(' for:', '')
+
+                            # check if we can find arch car name nearby (-3 lines and +5 lines)
+                            $a = Select-String $readme -pattern "$car" -Context 3,5
+                            if ($a -match $arch_car) {
+                                $kunos_car = $car
+                            }
+                        }
                     }
 
                     if ($kunos_car -eq "") {

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -25,21 +25,16 @@ if (Test-Path -Path "ARCH_CARS_UPDATE_LOG.txt"  -PathType Leaf) {
 }
 
 
-$common_ac_paths = @(
-    "${Env:ProgramFiles(x86)}\Steam\steamapps\common\assettocorsa",
-    "${Env:ProgramFiles}\Steam\steamapps\common\assettocorsa"
-)
-
 $script:ac_root = 0
 
 function Find-Ac {
-    foreach ($path in $common_ac_paths) {
-        if (Test-Path -Path $path) {
-            Write-Host ''
-            $answer = read-host -prompt "Found Assetto Corsa in $path, is this correct? (y/n)"
-            if ($answer -eq "y") {
-                $script:ac_root = $path
-            }
+    $steam_install_location = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 244210" -Name InstallLocation).InstallLocation
+
+    if (Test-Path -Path $steam_install_location) {
+        Write-Host ''
+        $answer = read-host -prompt "Found Assetto Corsa in $path, is this correct? (y/n)"
+        if ($answer -eq "y") {
+            $script:ac_root = $path
         }
     }
     if (-not($ac_root)) {

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -147,8 +147,7 @@ foreach ($dir in $dirs) {
                         Write-Host "Could not find kunos car for $arch_car, this is bad." -BackgroundColor Red
                         Start-Sleep -s 3
                     } else {
-                        $path = -join($ac_root, "\content\cars\", $kunos_car);
-                        if (Test-Path -Path $path) {
+                        if (Test-Path -Path "$ac_root\content\cars\$kunos_car\data.acd" -PathType Leaf) {
                             $absoluteDir = "$script:girellu\Releases\Mods\Arch Cars Public\$dir"
                             Install-Car $absoluteDir $arch_car $kunos_car $ac_root
                         } else {

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -121,17 +121,10 @@ $dirs = Get-ChildItem -Path "$script:girellu\Releases\Mods\Arch Cars Public\"
 
 foreach ($dir in $dirs) {
     if (Test-Path -Path "$dir\content\cars\") {
-
-
         $arch_cars = $()
-
         # get all folders inside "$dir\content\cars\" and add them to $arch_cars array
         $arch_cars = Get-ChildItem -Path "$dir\content\cars\"
-
-
         $arch_cars = $arch_cars | Select-Object -Unique
-
-    
 
         foreach ($arch_car in $arch_cars) {
             if ($arch_car -match "_") {
@@ -139,31 +132,27 @@ foreach ($dir in $dirs) {
                     $kunos_car = ""
 
                     $ext_config = Get-Content -Path "$dir\content\cars\$arch_car\extension\ext_config.ini"
-
                     $ext_config | Where-Object { $_ -match "cars/kunos/" } | Select-String -Pattern "cars/kunos/(.*).ini" | ForEach-Object { $kunos_car = @($_.Matches.Value) }
-
+                    
                     # strip .ini and "cars/kunos/" from $kunos_car
                     $kunos_car = $kunos_car.Replace(".ini", "").Replace("cars/kunos/", "")
-
                     if ($kunos_car -eq "") {
                         # read "!README AND INSTRUCTIONS.txt" in $dir
                         $readme = Get-Content -Path "$dir\!README AND INSTRUCTIONS.txt"
-
                         # find line with "copy from folder" inside $readme and strip it
                         $readme | Where-Object { $_ -match "copy from folder" } | Select-String -Pattern "copy from folder(.*)" | ForEach-Object { $kunos_car = @($_.Matches.Value).Replace("copy from folder ", "") }
-
-                        Write-Host "alternative check $kunos_car succesful" -ForegroundColor Green
                     }
 
                     if ($kunos_car -eq "") {
-                        Write-Host "Could not find kunos car for $arch_car" -ForegroundColor Red
+                        Write-Host "Could not find kunos car for $arch_car, this is bad." -BackgroundColor Red
+                        Start-Sleep -s 3
                     } else {
                         $path = -join($ac_root, "\content\cars\", $kunos_car);
-
                         if (Test-Path -Path $path) {
                             Install-Car $dir $arch_car $kunos_car $ac_root
                         } else {
-                            Write-Host "Could not find $kunos_car, you may be missing DLC, this car will be skipped." -BackgroundColor Red
+                            Write-Host "Could not find $kunos_car in your game files, you may be missing DLC, this car will be skipped." -BackgroundColor Red
+                            Start-Sleep -s 5
                         }
                     }
                 }

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -120,10 +120,11 @@ function Install-Car {
 $dirs = Get-ChildItem -Path "$script:girellu\Releases\Mods\Arch Cars Public\"
 
 foreach ($dir in $dirs) {
-    if (Test-Path -Path "$dir\content\cars\") {
+    $absolutePath = "$script:girellu\Releases\Mods\Arch Cars Public\$dir"
+    if (Test-Path -Path "$absolutePath\content\cars\") {
         $arch_cars = $()
         # get all folders inside "$dir\content\cars\" and add them to $arch_cars array
-        $arch_cars = Get-ChildItem -Path "$dir\content\cars\"
+        $arch_cars = Get-ChildItem -Path "$absolutePath\content\cars\"
         $arch_cars = $arch_cars | Select-Object -Unique
 
         foreach ($arch_car in $arch_cars) {
@@ -143,7 +144,7 @@ foreach ($dir in $dirs) {
                     }
                     
                     if ($kunos_car -eq "") { # this should only get triggered if new cars werent added to donor_cars.txt
-                        $ext_config = Get-Content -Path "$dir\content\cars\$arch_car\extension\ext_config.ini"
+                        $ext_config = Get-Content -Path "$absolutePath\content\cars\$arch_car\extension\ext_config.ini"
                         $ext_config | Where-Object { $_ -match "cars/kunos/" } | Select-String -Pattern "cars/kunos/(.*).ini" | ForEach-Object { $kunos_car = @($_.Matches.Value) }
                         
                         # strip .ini and "cars/kunos/" from $kunos_car
@@ -151,7 +152,7 @@ foreach ($dir in $dirs) {
                     }
                     if ($kunos_car -eq "") { # ideally, this should never get triggered, because it's horrible code that will likely fail
                         # read "!README AND INSTRUCTIONS.txt" in $dir
-                        $readme = Get-Content -Path "$dir\!README AND INSTRUCTIONS.txt"
+                        $readme = Get-Content -Path "$absolutePath\!README AND INSTRUCTIONS.txt"
                         $kunos_candidates = $()
                         # find every occurance of line with "copy from folder" or "Repeat process from folder" inside $readme and insert them into kunos_candidates array
                         $kunos_candidates = $readme | Where-Object {  $_ -match "copy from folder" -or $_ -match "Repeat process from folder" } 
@@ -173,8 +174,7 @@ foreach ($dir in $dirs) {
                         Start-Sleep -s 3
                     } else {
                         if (Test-Path -Path "$ac_root\content\cars\$kunos_car\data.acd" -PathType Leaf) {
-                            $absoluteDir = "$script:girellu\Releases\Mods\Arch Cars Public\$dir"
-                            Install-Car $absoluteDir $arch_car $kunos_car $ac_root
+                            Install-Car $absolutePath $arch_car $kunos_car $ac_root
                         } else {
                             Write-Host "Could not find $kunos_car in your game files, you may be missing DLC, this car will be skipped." -BackgroundColor Red
                             Start-Sleep -s 5

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -149,7 +149,8 @@ foreach ($dir in $dirs) {
                     } else {
                         $path = -join($ac_root, "\content\cars\", $kunos_car);
                         if (Test-Path -Path $path) {
-                            Install-Car $dir $arch_car $kunos_car $ac_root
+                            $absoluteDir = "$script:girellu\Releases\Mods\Arch Cars Public\$dir"
+                            Install-Car $absoluteDir $arch_car $kunos_car $ac_root
                         } else {
                             Write-Host "Could not find $kunos_car in your game files, you may be missing DLC, this car will be skipped." -BackgroundColor Red
                             Start-Sleep -s 5

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -32,9 +32,9 @@ function Find-Ac {
 
     if (Test-Path -Path $steam_install_location) {
         Write-Host ''
-        $answer = read-host -prompt "Found Assetto Corsa in $path, is this correct? (y/n)"
+        $answer = read-host -prompt "Found Assetto Corsa in $steam_install_location, is this correct? (y/n)"
         if ($answer -eq "y") {
-            $script:ac_root = $path
+            $script:ac_root = $steam_install_location
         }
     }
     if (-not($ac_root)) {


### PR DESCRIPTION
Entirely foregoes the manual configuration of arch cars, ~~instead the script will (attempt to) automatically determine the respective kunos cars, of note is that this attempt needs the `config was prepared automatically` header with the URL to the original file, as it uses that to figure out the kunos donor car.
if that fails then it will attempt to parse the readme file, it will (badly) attempt to figure out which kunos car to use, this will likely break with cars that have different variations.~~

The script will read out of the donor_cars.txt and prepare the cars that way, this is hopefully less of a pain than the previous "add 4 lines for every vehicle" method was.

I also updated the AC Path check, it will now attempt to read the path from the regkey steam creates, should be more reliable.