### PR TITLE
Improve and simplify install script

### DIFF
--- a/Releases/Mods/Arch Cars Public/README.md
+++ b/Releases/Mods/Arch Cars Public/README.md
@@ -4,9 +4,9 @@
 * All Arch cars will eventually be updated to Cosmic suspension type. To know about more cosmic suspension type, click [here](https://github.com/ac-custom-shaders-patch/acc-extension-config/wiki/Cars-%E2%80%93-Cosmic-Suspension "GitHub").
 * Non cosmic suspension data will be moved to the legacy folder for archival purposes and thereby will no longer receive support.
 ## Installation
-The install_arch_cars.bat script will automate installing of the car mods inside this folder. If you want to individually download cars, then you will have to manually install them.
-### Automated .bat script install (recommended method, installs all cars)
-Run the install_arch_cars.bat script and follow instructions within. Any errors mean you are missing a mod or AC DLC content.
+The install_arch_cars.ps1 script will automate installing of the car mods inside this folder. If you want to individually download cars, then you will have to manually install them.
+### Automated script install (recommended method, installs all cars)
+Run the install_arch_cars.ps1 script (right click -> Run with PowerShell) and follow instructions within. Any errors mean you are missing a mod or AC DLC content.
 
 ___
 #### Additional notes

--- a/Releases/Mods/Arch Cars Public/donor_cars.txt
+++ b/Releases/Mods/Arch Cars Public/donor_cars.txt
@@ -1,3 +1,7 @@
+a3dr_porsche_993_c2,a3dr_porsche_993_c2
+a3dr_porsche_993_c4,a3dr_porsche_993_c4
+a3dr_porsche_993_turbo,a3dr_porsche_993_turbo
+a3dr_porsche_993_turbo_s2,a3dr_porsche_993_turbo_s2
 arch_bmw_e30_1986_m3,bmw_m3_e30
 arch_bmw_e82_2011_1m,bmw_1m
 arch_bmw_e89_2010_z4_35i,bmw_z4
@@ -28,3 +32,5 @@ arch_ruf_ctr_1987,ruf_yellowbird
 arch_toyota_ae86_1983_gtv,ks_toyota_ae86
 arch_toyota_gt86_2015_gt,ks_toyota_gt86
 arch_toyota_supra_a80_1997_rz,ks_toyota_supra_mkiv
+lk_nissan_180sx_96,lk_nissan_180sx_96
+lk_nissan_180sx_96_drift,lk_nissan_180sx_96_drift

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.bat
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.bat
@@ -1,1 +1,0 @@
-powershell -executionpolicy bypass -noexit -nologo -File .\install_arch_cars.ps1

--- a/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
+++ b/Releases/Mods/Arch Cars Public/install_arch_cars.ps1
@@ -1,202 +1,115 @@
-$script:commit = "master" # the commit, or branch to download, master is fine.
-$script:girellu = $pwd
 Clear-Host
+Write-Host ""
 
-if (Test-Path -Path "ARCH_CARS_UPDATE_LOG.txt"  -PathType Leaf) {
-    Write-Host 'We are working from the mod folder, proceeding to install.'
-    $script:girellu = Split-Path -Resolve "$script:girellu\..\.."
-} else {
-    Write-Host 'Downloading Arch''s physics from github.com/archibaldmilton/Girellu...'
+# these paths need to be updated if Girellu directory structure changes
+$script:girelluRoot = Split-Path -Resolve "$pwd\..\.."
+$script:archCarsRoot = "$script:girelluRoot\Releases\Mods\Arch Cars Public\ARCH_CARS"
+$script:donorCars = Get-Content -Path "$script:girelluRoot\Releases\Mods\Arch Cars Public\donor_cars.txt"
 
-    $webclient = New-Object System.Net.WebClient
-    $url = "https://github.com/archibaldmilton/Girellu/archive/$script:commit.zip"
-    $zip = "$pwd\girellu.zip"
-    $webclient.DownloadFile($url, $zip)
-
-    $script:girellu = "$pwd\Girellu-$script:commit"
-    if (Test-Path -Path $script:girellu) {
-        Remove-Item $script:girellu -Recurse -Force
-    }
-
-    Write-Host 'Unzipping...'
-
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $pwd)
+if (-not($donorCars)) {
+    Write-Host "Failed to get cars to install from donor_cars.txt, cannot proceed" -BackgroundColor Red
+    Read-Host "Press Enter to close this window"
+    Exit
 }
 
-
-$script:ac_root = 0
+# finding AC install directory
+$script:acRoot = ""
 
 function Find-Ac {
-    $steam_install_location = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 244210" -Name InstallLocation).InstallLocation
-
-    if (Test-Path -Path $steam_install_location) {
-        Write-Host ''
-        $answer = read-host -prompt "Found Assetto Corsa in $steam_install_location, is this correct? (y/n)"
+    $steamInstallLocation = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 244210" -Name InstallLocation).InstallLocation
+    if (Test-Path -Path $steamInstallLocation) {
+        $answer = Read-Host -prompt "Found Assetto Corsa in $steamInstallLocation, is this correct? (y/n)"
         if ($answer -eq "y") {
-            $script:ac_root = $steam_install_location
+            $script:acRoot = $steamInstallLocation
         }
     }
-    if (-not($ac_root)) {
-        Write-Host 'Where is your Assetto Corsa root folder?'
-        Add-Type -AssemblyName System.Windows.Forms
-        $browser = New-Object System.Windows.Forms.FolderBrowserDialog -Property @{ Description = 'Select your Assetto Corsa root folder (usually it''s C:\Program Files\Steam\steamapps\common\assettocorsa)' }
-        [void] $browser.ShowDialog()
-        $script:ac_root = $browser.SelectedPath
+    if (-not($acRoot)) {
+        Write-Host "Where is your Assetto Corsa root folder?"
+        Add-Type -AssemblyName "System.Windows.Forms"
+        $browser = New-Object "System.Windows.Forms.FolderBrowserDialog" -Property @{ Description = "Select your Assetto Corsa root folder (usually it's C:\Program Files\Steam\steamapps\common\assettocorsa)" }
+        [void]$browser.ShowDialog()
+        $script:acRoot = $browser.SelectedPath
     }
-    
 }
+
 Find-Ac
 
+# installing cars
+$script:successfullInstalls = 0
+$script:failedInstalls = 0
 
 function Install-Car {
-    param(
-         [Parameter()]
-         [string]$arch_folder,
+    param ([string]$archCar, [string]$donorCar)
 
-         [Parameter()]
-         [string]$arch_car,
+    Write-Host ""
+    Write-Host "Installing $archCar, donor car is $donorCar..."
 
-         [Parameter()]
-         [string]$kunos_car,
+    $archCarSourcePath = "$script:archCarsRoot\content\cars\$archCar"
+    $donorCarPath = "$script:acRoot\content\cars\$donorCar"
+    $archCarDestinationPath = "$script:acRoot\content\cars\$archCar"
 
-         [Parameter()]
-         [string]$ac_root
-    )
-    $arch_physics = "$arch_folder\content\cars\$arch_car"
-
-    if (-not(Test-Path -Path "$ac_root\content\cars\$kunos_car\data.acd" -PathType Leaf)) {
-        Write-Host "ERROR: Can't find donor car to use visuals from (was looking for $kunos_car)"
-        Write-Host 'ERROR: Either the path to Assetto Corsa root folder is wrong, or the donor car is missing (DLC or missing mod?)'
-        $answer = read-host -prompt "Do you want to define a custom one? (y/n)"
-        if ($answer -eq "y") {
-            $kunos_car = read-host -prompt "Please enter the donor car's name now."
-            if (-not(Test-Path -Path "$ac_root\content\cars\$kunos_car\data.acd" -PathType Leaf)) {
-                Write-Host 'ERROR: Could not find the specified car, exiting.'
-                Exit
-            }
-        } else {
-            return
-        }
+    if (-not(Test-Path -Path "$donorCarPath\driver_base_pos.knh" -PathType Leaf)) {
+        Write-Host "Could not find the donor car $donorCar in your game files, skipping." -BackgroundColor Red
+        $script:failedInstalls++
+        Return
     }
 
-
-    Write-Host ''
-    Write-Host "Creating $arch_car, using visuals from $kunos_car"
-
-    if (-not($script:deleteArchCars -eq "a")) {
-        if (Test-Path -Path "$ac_root\content\cars\$arch_car") {
-            $script:deleteArchCars = read-host -prompt "$arch_car is already installed, clean install to ensure latest version? (y/n/a)"
-        }
-    }
-
-    if ($script:deleteArchCars -eq "a" -or $script:deleteArchCars -eq "y") {
-        Remove-Item "$ac_root\content\cars\$arch_car" -Recurse -Force
-        if ($script:deleteArchCars -eq "y") {
-            $script:deleteArchCars = 0 # clean up after ourselves
-        }
-    }
-
-    New-Item -ItemType "directory" -Path "$ac_root\content\cars\$arch_car" -Force
-    Get-ChildItem "$ac_root\content\cars\$kunos_car" | Copy-Item -Destination "$ac_root\content\cars\$arch_car" -Recurse -Force
-    Copy-Item "$arch_physics/*" -Destination "$ac_root\content\cars\$arch_car" -Recurse -Force
-    if (-not(Test-Path -Path "$ac_root\content\cars\$kunos_car\sfx\GUIDS.txt"  -PathType Leaf)) {
-        (Get-Content "$ac_root\content\sfx\GUIDS.txt") -Replace $kunos_car, $arch_car | Set-Content "$ac_root\content\cars\$arch_car\sfx\GUIDS.txt"
-        Rename-Item "$ac_root\content\cars\$arch_car\sfx\$kunos_car.bank" "$arch_car.bank"
-        Set-Content -Path "$ac_root\content\cars\$arch_car\sfx\GUIDS.txt" -Value (get-content -Path "$ac_root\content\cars\$arch_car\sfx\GUIDS.txt" | Select-String -Pattern "$arch_car/|grp_|common|bus:")
+    # prepare destination car directory
+    if (Test-Path -Path $archCarDestinationPath) {
+        # destination car already exists - either installed previously, or destination = donor; anyway, no need to copy anything
+        Write-Host "Updating existing car..." -NoNewline
     } else {
-        Write-Host "detected sound mod, adjusting existing guids.."
-        (Get-Content "$ac_root\content\cars\$arch_car\sfx\GUIDS.txt") -Replace $kunos_car, $arch_car | Set-Content "$ac_root\content\cars\$arch_car\sfx\GUIDS.txt"
-        Rename-Item "$ac_root\content\cars\$arch_car\sfx\$kunos_car.bank" "$arch_car.bank"
-    }
+        Write-Host "Creating new car $archCar..." -NoNewline
 
-    if (Test-Path "$arch_folder\extension\vao-patches-cars") {
-        Write-Host "found vaopatch, installing..."
-        Get-ChildItem "$arch_folder\extension\vao-patches-cars\" -Recurse | Copy-Item -Destination "$ac_root\extension\vao-patches-cars\" -Recurse
-    }
-}
+        # create the destination directory and copy everything from donor
+        [void](New-Item -ItemType "directory" -Path $archCarDestinationPath -Force)
+        Copy-Item "$donorCarPath\*" -Destination $archCarDestinationPath -Recurse -Force
 
-# get all folders inside "$script:girellu\Releases\Mods\Arch Cars Public\"
-$dirs = Get-ChildItem -Path "$script:girellu\Releases\Mods\Arch Cars Public\"
+        # sort out sfx
+        Rename-Item "$archCarDestinationPath\sfx\$donorCar.bank" "$archCar.bank"
+        if (-not(Test-Path -Path "$donorCarPath\sfx\GUIDS.txt" -PathType Leaf)) {
+            (Get-Content "$acRoot\content\sfx\GUIDS.txt") -Replace $donorCar, $archCar | Set-Content "$archCarDestinationPath\sfx\GUIDS.txt"
+            Set-Content -Path "$archCarDestinationPath\sfx\GUIDS.txt" -Value (Get-Content -Path "$archCarDestinationPath\sfx\GUIDS.txt" | Select-String -Pattern "$archCar/|grp_|common|bus:")
+        } else {
+            Write-Host " Detected sound mod, adjusting existing guids..." -NoNewline
+            (Get-Content "$archCarDestinationPath\sfx\GUIDS.txt") -Replace $donorCar, $archCar | Set-Content "$archCarDestinationPath\sfx\GUIDS.txt"
+        }
 
-foreach ($dir in $dirs) {
-    $absolutePath = "$script:girellu\Releases\Mods\Arch Cars Public\$dir"
-    if (Test-Path -Path "$absolutePath\content\cars\") {
-        $arch_cars = $()
-        # get all folders inside "$dir\content\cars\" and add them to $arch_cars array
-        $arch_cars = Get-ChildItem -Path "$absolutePath\content\cars\"
-        $arch_cars = $arch_cars | Select-Object -Unique
-
-        foreach ($arch_car in $arch_cars) {
-            if ($arch_car -match "_") {
-                if ($arch_car -inotmatch " ") {
-                    $kunos_car = ""
-
-
-                    if (Test-Path -Path "$script:girellu\Releases\Mods\Arch Cars Public\donor_cars.txt" -PathType Leaf) {
-                        $donor_cars = Get-Content -Path "$script:girellu\Releases\Mods\Arch Cars Public\donor_cars.txt"
-                        foreach ($donor_car in $donor_cars) {
-                            # seperate $donor_car by comma into array
-                            $donor_car = $donor_car -split ","
-                            # if $arch_car matches first entry, set $kunos_car to second entry
-                            if ($arch_car -match $donor_car[0]) {
-                                $kunos_car = $donor_car[1]
-                            }
-                        }
-                    } else {
-                        Write-Host "ERROR: Could not find donor_cars.txt, using fallback method" -ForegroundColor Red
-                    }
-                    
-                    if ($kunos_car -eq "") { # this should only get triggered if new cars werent added to donor_cars.txt
-                        $ext_config = Get-Content -Path "$absolutePath\content\cars\$arch_car\extension\ext_config.ini"
-                        $ext_config | Where-Object { $_ -match "cars/kunos/" } | Select-String -Pattern "cars/kunos/(.*).ini" | ForEach-Object { $kunos_car = @($_.Matches.Value) }
-                        
-                        # strip .ini and "cars/kunos/" from $kunos_car
-                        $kunos_car = $kunos_car.Replace(".ini", "").Replace("cars/kunos/", "")
-                    }
-                    if ($kunos_car -eq "") { # ideally, this should never get triggered, because it's horrible code that will likely fail
-                        # read "!README AND INSTRUCTIONS.txt" in $dir
-                        $readme = Get-Content -Path "$absolutePath\!README AND INSTRUCTIONS.txt"
-                        $kunos_candidates = $()
-                        # find every occurance of line with "copy from folder" or "Repeat process from folder" inside $readme and insert them into kunos_candidates array
-                        $kunos_candidates = $readme | Where-Object {  $_ -match "copy from folder" -or $_ -match "Repeat process from folder" } 
-
-                        foreach ($car in $kunos_candidates) {
-                            # strip "copy from folder " from $car
-                            $car = $car.Replace("copy from folder ", "").Replace('"', '').Replace('Repeat process from folder ', '').Replace(' for:', '')
-
-                            # check if we can find arch car name nearby (-3 lines and +5 lines)
-                            $a = Select-String $readme -pattern "$car" -Context 3,5
-                            if ($a -match $arch_car) {
-                                $kunos_car = $car
-                            }
-                        }
-                    }
-
-                    if ($kunos_car -eq "") {
-                        Write-Host "Could not find donor car for $arch_car, you will need to install this car manually." -BackgroundColor Red
-                        Start-Sleep -s 3
-                    } else {
-                        if (Test-Path -Path "$ac_root\content\cars\$kunos_car\data.acd" -PathType Leaf) {
-                            Install-Car $absolutePath $arch_car $kunos_car $ac_root
-                        } else {
-                            Write-Host "Could not find $kunos_car in your game files, you may be missing DLC, this car will be skipped." -BackgroundColor Red
-                            Start-Sleep -s 5
-                        }
-                    }
-                }
-            }
+        # install VAO patch if present
+        if (Test-Path -Path "$archCarDestinationPath\extension\vao-patches-cars") {
+            Write-Host " Found vaopatch, installing..." -NoNewline
+            Copy-Item "$archCarDestinationPath\extension\vao-patches-cars\*" -Destination "$script:acRoot\extension\vao-patches-cars\" -Recurse -Force
         }
     }
+
+    # delete any and all physics in the destination directory, to ensure clean install
+    if (Test-Path -Path "$archCarDestinationPath\data.acd") {
+        Remove-Item "$archCarDestinationPath\data.acd" -Force
+    }
+    if (Test-Path -Path "$archCarDestinationPath\data") {
+        Remove-Item "$archCarDestinationPath\data" -Recurse -Force
+    }
+
+    # copy stuff from Girellu
+    Copy-Item "$archCarSourcePath\*" -Destination $archCarDestinationPath -Recurse -Force
+
+    Write-Host " Done."
+    $script:successfullInstalls++
 }
 
-Write-Host 'Success!'
-Write-Host 'If your sounds are broken on certain cars you may need to replace them in CM:'
-Write-Host 'Open Content Manager, go to Content -> Cars, and search for "arch"'
-Write-Host 'You will find the created cars. For the broken cars, you have to:'
-Write-Host '1. Click Replace sound'
-Write-Host '2. Select car to use sounds from'
-Write-Host '3. Click OK'
-Write-Host ''
+Write-Host ""
+Write-Host "There are $($donorCars.Count) cars to install."
+Write-Host "Installation of some cars may fail if you are missing the corresponding `"donor car`" (= car to use visuals from)." -Foregroundcolor Gray
+Write-Host "That is fine, it won't prevent other cars from being installed correctly." -Foregroundcolor Gray
+Write-Host "Any existing physics data (packed or unpacked) in the destination folders will be deleted!"
+Read-Host "Press Enter to begin"
 
-Write-Host 'You can now close this window.'
+foreach ($line in $donorCars) {
+    $archCar = ($line -split ",")[0]
+    $donorCar = ($line -split ",")[1]
+    Install-Car $archCar $donorCar
+}
+
+Write-Host ""
+Write-Host "All done! $script:successfullInstalls cars installed successfully, $script:failedInstalls cars not installed."
+Read-Host "Press Enter to close this window"


### PR DESCRIPTION
Added:
* The script can now install all cars, even when destination = donor (that is the simplest case, after all).
* Added the previously unsupported cars to donor_cars.txt.
* Added a bit of user-friendliness (introductory message, better progress info).

Changed:
* The installation is now 100% based on donor_cars.txt. What isn't in donor_cars.txt doesn't get installed.
* When updating an already installed car, the script doesn't copy everything from the donor car again unnecessarily.
* When updating an already installed car, the script always deletes existing physics (packed or unpacked) to ensure clean install.

Removed:
* Removed the .bat "launcher" script and changed instructions in README to just right click and "Run with PowerShell".
* Removed the functionality to download the Girellu repo (that was my code from before the script was integrated into the repository).
* Removed all the donor finding/guessing logic - there's no "magic" now, the script just follows donor_cars.txt (see above).